### PR TITLE
Fixed Blog Post Pagination

### DIFF
--- a/src/_includes/partials/pagination.html
+++ b/src/_includes/partials/pagination.html
@@ -3,13 +3,13 @@
   <footer class="[ pagination ] [ dot-shadow panel ] [ bg-light-glare font-sans weight-bold ]">
     <div class="wrapper">
       <nav class="pagination__inner" aria-label="Pagination links">
-        {% if pagination.href.previous %}
-          <a href="{{ pagination.href.previous }}{{ paginationAnchor }}" data-direction="backwards">
+        {% if pagination.href.next %}
+          <a href="{{ pagination.href.next }}{{ paginationAnchor }}" data-direction="backwards">
             <span>{{ paginationPrevText if paginationPrevText else 'Previous' }}</span>
           </a>
         {% endif %}
-        {% if pagination.href.next %}
-          <a href="{{ pagination.href.next }}{{ paginationAnchor }}" data-direction="forwards">
+        {% if pagination.href.previous %}
+          <a href="{{ pagination.href.previous }}{{ paginationAnchor }}" data-direction="forwards">
             <span>{{ paginationNextText if paginationNextText else 'Next' }}</span>
           </a>
         {% endif %}

--- a/src/blog.md
+++ b/src/blog.md
@@ -6,8 +6,8 @@ const pagination = {
   size: 5
 };
 const permalink = "blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber }}{% endif %}/index.html"
-const paginationPrevText = "Newer posts"
-const paginationNextText = "Older posts"
+const paginationPrevText = "Older posts"
+const paginationNextText = "Newer posts"
 const paginationAnchor = "#post-list"
 
 function currentDate() {


### PR DESCRIPTION
Fixed the pagination labels so that they display consistently when paging through blog post lists. The Older posts label will always be on the left whereas the Newer posts label will be displayed on the right like flicking through a book.

Pagination data-direction logic has also been fixed to fit the context of the blog posts being sorted from newest to oldest. Clicking the `pagination.href.next` link (Older posts) would be going backwards whereas clicking the `pagination.href.previous` link (Newer posts) would be going forwards.