### PR TITLE
Reverted Pagination, Removed Async Functions and Stray Footer Fix

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -14,22 +14,22 @@ export default async function(eleventyConfig) {
     eleventyConfig.addPlugin(rssPlugin);
 
     //Creates and returns a collection of work
-    eleventyConfig.addCollection("work", async (collection) => {
+    eleventyConfig.addCollection("work", collection => {
       return sortByDisplayOrder(collection.getFilteredByGlob('./src/work/*.md'));
     });
 
     //Creates and returns a collection of work that is set to be featured
-    eleventyConfig.addCollection("featuredWork", async (collection) => {
+    eleventyConfig.addCollection("featuredWork", collection => {
       return sortByDisplayOrder(collection.getFilteredByGlob('./src/work/*.md')).filter(x => x.data.featured);
     });
 
     //Creates and returns a collection of blog posts in reverse date order
-    eleventyConfig.addCollection("blog", async (collection) => {
+    eleventyConfig.addCollection("blog", collection => {
       return [...collection.getFilteredByGlob('./src/posts/*.md')].reverse();
     });
 
     //Creates and returns a collection of people ordered by file name (just a single integer)
-    eleventyConfig.addCollection("people", async (collection) => {
+    eleventyConfig.addCollection("people", collection => {
       return collection.getFilteredByGlob('./src/people/*.md').sort((a, b) => {
         return Number(a.fileSlug) > Number(b.fileSlug) ? 1: -1;
       });

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -11,9 +11,9 @@
   <body>
     {% include "partials/site-head.html" %}
     <main tabindex="-1" id="main-content">{% block content %}{% endblock %}</main>
+    <footer>
+      <p><em>{{ site.siteInfo.published }}{{ site.publishedDate() | dateFilter(locale) }}</em></p>
+      <p><em>{{ site.siteInfo.updated }}{{ currentDate() | dateFilter(locale) }}</em></p>
+    </footer>
   </body>
-  <footer>
-  <p><em>{{ site.siteInfo.published }}{{ site.publishedDate() | dateFilter(locale) }}</em></p>
-  <p><em>{{ site.siteInfo.updated }}{{ currentDate() | dateFilter(locale) }}</em></p>
-  </footer>
 </html>

--- a/src/_includes/partials/pagination.html
+++ b/src/_includes/partials/pagination.html
@@ -3,13 +3,13 @@
   <footer class="[ pagination ] [ dot-shadow panel ] [ bg-light-glare font-sans weight-bold ]">
     <div class="wrapper">
       <nav class="pagination__inner" aria-label="Pagination links">
-        {% if pagination.href.next %}
-          <a href="{{ pagination.href.next }}{{ paginationAnchor }}" data-direction="backwards">
+        {% if pagination.href.previous %}
+          <a href="{{ pagination.href.previous }}{{ paginationAnchor }}" data-direction="backwards">
             <span>{{ paginationPrevText if paginationPrevText else 'Previous' }}</span>
           </a>
         {% endif %}
-        {% if pagination.href.previous %}
-          <a href="{{ pagination.href.previous }}{{ paginationAnchor }}" data-direction="forwards">
+        {% if pagination.href.next %}
+          <a href="{{ pagination.href.next }}{{ paginationAnchor }}" data-direction="forwards">
             <span>{{ paginationNextText if paginationNextText else 'Next' }}</span>
           </a>
         {% endif %}

--- a/src/blog.md
+++ b/src/blog.md
@@ -6,8 +6,8 @@ const pagination = {
   size: 5
 };
 const permalink = "blog{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber }}{% endif %}/index.html"
-const paginationPrevText = "Older posts"
-const paginationNextText = "Newer posts"
+const paginationPrevText = "Newer posts"
+const paginationNextText = "Older posts"
 const paginationAnchor = "#post-list"
 
 function currentDate() {


### PR DESCRIPTION
First, fixed stray footer tag in `base.html` by moving it inside the body tags. Next I removed the `async` functions from the `addCollection` functions in the configuration as they're not doing anything in that context.

Lastly, I reverted the pagination changes because after thinking about it, I have come to the conclusion they were not problematic to begin with when compared to the finished site. The labels used might not make sense but they fit the paging context well especially considering the fallback label in place. The attribute `data-direction` never referred to the chronological order of blog posts either. It was meant to help with positioning the element. The rendering order of elements was also fine before (again, comparing it to the finished site, it makes sense).