### PR TITLE
Post.html Now Sets Locale Information at the Start of Site Rendering

### DIFF
--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -1,6 +1,7 @@
 {% extends "layouts/base.html" %}
 
 {% set pageHeaderTitle = title %}
+{% set locale = language %}
 
 {# Grab other posts that aren’t this one for the 'more from the blog' feed #}
 {% set recommendedPosts = helpers.urlChecker.getSiblingContent(collections.blog, page) %}


### PR DESCRIPTION
While working on a different implementation of the site, I identified from tests that when blog posts were being rendered by Eleventy, `locale` was undefined (at least during the start of rendering) where it should at minimum, be assigned an empty string from `language.js`. I have implemented it so that in `post.html`, it now gets assigned a `locale` value. I thought `base.html` would have done this automatically setting `locale` data there but no, I needed to set `locale` in `post.html` as well.